### PR TITLE
IRCv3 Monitor S

### DIFF
--- a/bouncer.js
+++ b/bouncer.js
@@ -40,6 +40,7 @@ const SERVER_PORT = BOUNCER_MODE=='gateway'?(config.serverPort?config.serverPort
 const INGRESSWEBIRC = config.ingresswebircPassword?config.ingresswebircPassword:'';
 const SERVER = BOUNCER_MODE=='gateway'?(config.server?config.server:''):'';
 const DEBUG = config.debug?config.debug:false;
+const IRCV3_MONITOR = config.ircv3Monitor?true:false;
 
 
 // Reload passwords on sighup
@@ -645,6 +646,8 @@ function clientReconnect(socket) {
     socket.write(connection.connectbuf+"\n");
     if(connection.nick!=socket.irc.nick)
       socket.write(":"+connection.nick_original+" NICK "+connection.nick+"\n");
+    if (IRCV3_MONITOR)
+      connection.write("MONITOR S\n");
     if(!connection.connected) {
       connection.write("AWAY\n");
       connection.connected=true;

--- a/examples/example.conf
+++ b/examples/example.conf
@@ -19,5 +19,7 @@
   "bufferMaxSize":52428800,
   "bouncerDefaultOpmode":false,
 
+  "ircv3Monitor": false,
+
   "debug":false
 }


### PR DESCRIPTION
Enables calling 'MONITOR S' upon reconnection to receive a list of users connected/disconnected from favorites. To create the list, simply use 'MONITOR +' from the client, likewise for removal.