### PR TITLE
Update ERROR bouncer.js

### DIFF
--- a/bouncer.js
+++ b/bouncer.js
@@ -1425,6 +1425,12 @@ function clientConnect(socket) {
             this.write("PONG "+data[1].substr(1).trim()+"\n");
             continue;
           }
+          if (data[0] == "ERROR") {
+            if(this.gone) {
+              clearTimeout(this.gone);
+              this.gone='';
+            }
+          }
           if(lines[n].length>1) {
             for(m=0;m<this.parents.length;m++) {
               this.parents[m].write(lines[n]+"\n");


### PR DESCRIPTION
This fix addresses an issue where a user's BNC receives a /kill from an IRCop.

To reproduce the bug before the update:
1) The user is connected to their BNC.
2) Disconnect using `/quit` (not `/jbnc quit`).
3) Reconnect.
4) The IRCop sends `/kill` to the user's BNC.
5) Reconnect and wait for the duration of the `bouncerTimeout` (I've set it to 20 seconds). After 20 seconds, the `gone=setTimeout()` is still executed and should not be.

I haven't tested it with glines/zlines, etc.
