### PR TITLE
Correction of the change nickname conflict and update of the page web admin

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -393,7 +393,7 @@ class Server {
                                 case 'NICK':
                                     if (socket.hash && this.connections[socket.hash] && command[1]) {
                                         this.connections[socket.hash].write("NICK " + command[1] + "\n");
-                                        this.connections[socket.hash].nick = command[1];
+                                        //this.connections[socket.hash].nick = command[1];
                                     }
                                     break;
                                 case 'JBNC':

--- a/lib/WebAdminPanel.js
+++ b/lib/WebAdminPanel.js
@@ -61,6 +61,9 @@ class WebAdminPanel {
             let connection = {
               key: key,
               nick: this.connections[key].nick,
+              user: this.connections[key].user,
+              host: this.connections[key].host,
+              realname: this.connections[key].realname,
               channelCount: this.instanceConnections.userChannelCount(key)
             };
             connectionsData.push(connection);

--- a/lib/webadminpanel/dashboard.html
+++ b/lib/webadminpanel/dashboard.html
@@ -10,6 +10,9 @@
         body {
             padding: 0 20px;
         }
+        li {
+            margin: 3px;
+        }
     </style>
 </head>
 
@@ -21,7 +24,7 @@
         <h2 class="mt-4">Connections (total: {{ count }}) :</h2>
         <ul>
             <li v-for="connection in connections" :key="connection.id">
-                Key: {{ connection.key }} - Nick: {{ connection.nick }} - Number of channels: {{ connection.channelCount }} - <button class="kill" :data-key="connection.key">Kill</button>
+                Key: {{ connection.key }} - Nick: {{ connection.nick }} - User: {{ connection.user }} - Host: {{ connection.host }} - Number of channels: {{ connection.channelCount }} - <button class="kill btn btn-primary" @click="removeConnection(connection.key, $event)">Kill</button>
             </li>
         </ul>
     </div>
@@ -54,22 +57,11 @@
                         .catch(error => {
                             console.error('Error while retrieving data:', error);
                         });
-                }
-            },
-            mounted() {
-                this.fetchData();
-                setInterval(() => {
-                    this.fetchData();
-                }, 5000);
-            }
-        });
-
-        document.addEventListener("DOMContentLoaded", function() {
-            document.addEventListener("click", function(event) {
-                if (event.target.classList.contains('kill')) {
+                },
+                removeConnection(key, event) {
                     var data = {
                         command: "kill",
-                        key: event.target.getAttribute('data-key')
+                        key: key
                     };
 
                     var url = new URL("/send", window.location.origin);
@@ -83,10 +75,14 @@
                                 throw new Error('Error fetching data');
                             }
                         })
-                        .then(function(data) {
+                        .then((data) => {
                             if (data == "disconnected") {
                                 event.target.innerText="disconnected !";
-                                event.target.disabled=true;
+                                const index = this.connections.findIndex(connection => connection.key === key);
+                                if (index !== -1) {
+                                    this.connections.splice(index, 1);
+                                    this.count--;
+                                }
                             }
                             else 
                                 console.log("Error !");
@@ -95,10 +91,14 @@
                             console.error("Error sending request:", error);
                         });
                 }
-            });
+            },
+            mounted() {
+                this.fetchData();
+                setInterval(() => {
+                    this.fetchData();
+                }, 5000);
+            }
         });
-
-
 
     </script>
 </body>


### PR DESCRIPTION
In Server.js, the " `//this.connections[socket.hash].nick = command[1];`" line was commented out four years ago due to an issue with nickname changes if left uncommented.

If uncommented, here's how to reproduce a bug: 
1) Uncomment the line.
2) Connect to JBNC on IRC.
3) Change your nickname to "`/nick afk`" using an ircd module like nicklock on UnrealIRCd. This module allows keeping the nickname "nick" and adds "|afk" at the end; nick|afk. So, when you type `/nick afk`, your "`connection.nick`" will only change to "afk".
4) Disconnect from the BNC (without typing `/jbnc quit`) and reconnect.
5) Type a message in a channel or PM, and you will see yourself with the nickname "afk" but not others.
6) Another bug can also be observed by typing "`/nick me`" to reset your nickname. Disconnect/reconnect to jbnc without typing '`/jbnc quit`" and you will see yourself as "`me`".

Commenting out this line prevents the bug from occurring. There is also nickname change monitoring in the code, which is here: https://github.com/freenode/jbnc/blob/master/lib/ClientConnect.js#L698
