### PR TITLE
Update ClientConnect.js

### DIFF
--- a/lib/ClientConnect.js
+++ b/lib/ClientConnect.js
@@ -770,11 +770,15 @@ class ClientConnect {
                         continue;
                     }
                     if (data[0] == "ERROR") {
-                        if (this.client.gone) {
+                        /*if (this.client.gone) {
                             clearTimeout(this.client.gone);
                             this.client.gone = '';
                             this.client.goneTime = '';
-                        }
+                        }*/
+                        try {
+                            this.connections[this.client.hash].end();
+                        } catch (e) { }
+                        delete this.connections[this.client.hash];
                     }
                     if (lines[n].length > 1) {
                         for (let m = 0; m < this.client.parents.length; m++) {
@@ -850,6 +854,9 @@ class ClientConnect {
                             }
                         }
                         else if (lines[n].split(" ")[2] && global.ircCommandRedistributeMessagesOnConnect.has(lines[n].split(" ")[2].trimEnd())) {
+                            if (lines[n].split(" ")[1].substr(1).split("!")[0] == this.client.nick) {
+                                continue;
+                            }
                             for (let key in this.client.buffers) {
                                 if (Object.prototype.hasOwnProperty.call(this.client.buffers, key)) {
                                     let _n = "server.irc";


### PR DESCRIPTION
Corrections for 2 issues:

1. The first issue is a bug posted here: https://github.com/freenode/jbnc/issues/78#issuecomment-2106363138
2. The second issue (which is triggered on my end by `global.MSG_REDISTRIBUTION`) prevents tracking our actions like `PART` and others because when reconnecting, the `PART` event was triggered. For example, if we left a channel, rejoined it, then quit the client (without doing `/jbnc quit`), and later reconnected, the client would receive the `PART` event and the jbnc user would disconnect from the channel again. By correcting it as this suggested, the bug no longer occurs.