### PR TITLE
Added RPL_HOSTHIDDEN

### DIFF
--- a/lib/ClientConnect.js
+++ b/lib/ClientConnect.js
@@ -74,6 +74,7 @@ class ClientConnect {
             this.client.hash = socket.hash;
             this.client.serverpassword = socket.irc.serverpassword;
             this.client.host = socket.host != null ? socket.host : (socket.remoteAddress.substr(0, 7) == "::ffff:" ? socket.remoteAddress.substr(7) : socket.remoteAddress);
+            this.client.vhost = false;
             this.client.umode = '';
             this.client.motd = '';
             this.client.channels = {};
@@ -531,6 +532,9 @@ class ClientConnect {
                         case '376': // RPL_ENDOFMOTD
                             this.client.motd += lines[n] + "\n";
                             //this.client.motd='';
+                            break;
+                        case '396': // RPL_HOSTHIDDEN
+                            this.client.vhost = data[3];
                             break;
                         case 'JOIN':
                             // <- @msgid=pHZAZJUGTgmdLbzMnFYZ5l-xBZH2fjfPCVLEsLqwDqtsA;time=2022-07-19T17:21:44.038Z :nick!ident@host JOIN #channel * :<realname>

--- a/lib/ClientConnect.js
+++ b/lib/ClientConnect.js
@@ -534,7 +534,8 @@ class ClientConnect {
                             //this.client.motd='';
                             break;
                         case '396': // RPL_HOSTHIDDEN
-                            this.client.vhost = data[3];
+                            if(data[3])
+                                this.client.vhost = data[3];
                             break;
                         case 'JOIN':
                             // <- @msgid=pHZAZJUGTgmdLbzMnFYZ5l-xBZH2fjfPCVLEsLqwDqtsA;time=2022-07-19T17:21:44.038Z :nick!ident@host JOIN #channel * :<realname>

--- a/lib/ClientReconnect.js
+++ b/lib/ClientReconnect.js
@@ -117,6 +117,9 @@ class ClientReconnect {
           if (global.DEBUG)
             console.log("\n:*jbnc 366 " + this.connection.nick + " " + key + " :End of /NAMES list.\n");
           this.write(socket, "\n:*jbnc 366 " + this.connection.nick + " " + key + " :End of /NAMES list.\n");
+
+          if (this.connection.vhost)
+            this.write(socket, "\n:*jbnc 396 " + this.connection.nick + " " + this.connection.vhost + " :is now your displayed host\n");
         }
       }
 


### PR DESCRIPTION
If we receive an automatic or manual vhost: as soon as we connect to IRC with JBNC, the vhost is received correctly. However, if we reconnect to IRC (without doing /jbnc quit), the vhost is not received by JBNC. Now yes, with this update, it's okay.